### PR TITLE
fix(workflow): Change homebrew/core to be forced tapped

### DIFF
--- a/.github/workflows/bump-formulae.yml
+++ b/.github/workflows/bump-formulae.yml
@@ -27,7 +27,7 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@c43c466dcf8d9713ccd8ce26f316a7f6c4d6d1dc
         
       - name: Tap homebrew/core
-        run: brew tap homebrew/core
+        run: brew tap --force homebrew/core
         
       - name: Install ESPHome
         run: brew install esphome


### PR DESCRIPTION
The tap is needed to run homebrew bump formulae logic