### PR TITLE
chore(workflow): Remove version pin

### DIFF
--- a/.github/workflows/bump-formulae.yml
+++ b/.github/workflows/bump-formulae.yml
@@ -12,19 +12,19 @@ jobs:
 
     steps:
       - name: Configure git
-        uses: Homebrew/actions/git-user-config@c43c466dcf8d9713ccd8ce26f316a7f6c4d6d1dc
+        uses: Homebrew/actions/git-user-config@master
         with:
           username: bobsoppe
 
       - name: Set up GPG commit signing
         id: set-up-commit-signing
-        uses: Homebrew/actions/setup-commit-signing@c43c466dcf8d9713ccd8ce26f316a7f6c4d6d1dc
+        uses: Homebrew/actions/setup-commit-signing@master
         with:
           signing_key: ${{ secrets.GPG_SIGNING_KEY }}
 
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@c43c466dcf8d9713ccd8ce26f316a7f6c4d6d1dc
+        uses: Homebrew/actions/setup-homebrew@master
         
       - name: Tap homebrew/core
         run: brew tap --force homebrew/core
@@ -33,7 +33,7 @@ jobs:
         run: brew install esphome
 
       - name: Bump formulae
-        uses: Homebrew/actions/bump-formulae@c43c466dcf8d9713ccd8ce26f316a7f6c4d6d1dc
+        uses: Homebrew/actions/bump-formulae@master
         with:
           token: ${{secrets.TOKEN}}
           formulae: esphome


### PR DESCRIPTION
Homebrew/actions does not use releases, so dependabot is not able to auto update these actions